### PR TITLE
Docs: Add OpenAPI Swagger/ReDoc + metric bluepirnt description

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -67,11 +67,11 @@ def create_app(config_name: str = "development"):
     from app.blueprints.alerts import alerts_bp, sock
     from app.blueprints.health import health_bp
 
-    app.register_blueprint(auth_bp)      # Auth endpoints (/auth)
-    app.register_blueprint(orders_bp)    # Orders endpoints (/orders)
-    app.register_blueprint(metrics_bp)   # Metrics endpoints (/metrics)
-    app.register_blueprint(alerts_bp)    # Alerts endpoints (/alerts)
-    app.register_blueprint(health_bp)    # Health endpoint (/healthz) 
+    api.register_blueprint(auth_bp)      # Auth endpoints (/auth)
+    api.register_blueprint(orders_bp)    # Orders endpoints (/orders)
+    api.register_blueprint(metrics_bp)   # Metrics endpoints (/metrics)
+    api.register_blueprint(alerts_bp)    # Alerts endpoints (/alerts)
+    api.register_blueprint(health_bp)    # Health endpoint (/healthz) 
     sock.init_app(app)                   # bind WebSocket routes to this app
 
     # ------------------------------------------------------------------

--- a/app/blueprints/metrics.py
+++ b/app/blueprints/metrics.py
@@ -27,7 +27,7 @@ from app.utils.helpers import parse_monthish
 # ----------------------------------------------------------------------
 # Blueprint Setup
 # ----------------------------------------------------------------------
-metrics_bp = Blueprint("metrics", __name__, url_prefix="/metrics")
+metrics_bp = Blueprint("metrics", __name__, url_prefix="/metrics", description="Analytics endpoints for customer insights (AOV, RFM, Cohorts).")
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Docs: Enable OpenAPI with Swagger/ReDoc
This PR adds full API documentation with Flask-Smorest, Swagger UI at /api/docs, and ReDoc at /api/redoc.