### PR TITLE
Fix CI: use TestConfig in scheduler test

### DIFF
--- a/tests/unit/test_app_init_scheduler.py
+++ b/tests/unit/test_app_init_scheduler.py
@@ -5,7 +5,7 @@ Covers the scheduler startup branch in app/__init__.py.
 from app import create_app
 
 def test_scheduler_starts(monkeypatch):
-    app = create_app("development")
+    app = create_app("testing")
     # Scheduler should register unless explicitly disabled
     assert "alerts_scheduler" in app.extensions
     assert getattr(app, "_alerts_scheduler_started", False)


### PR DESCRIPTION
Updated tests/unit/test_app_init_scheduler.py for testing configuration.