### PR TITLE
CI: add postgres+redis, run db upgrade + seed-demo before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,26 @@ jobs:
   build-test-push:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:15
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: insightful_orders_test
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+
     steps:
       # Step 1 - Checkout repo
       - name: Checkout code
@@ -28,15 +48,28 @@ jobs:
           pip install -r requirements.txt
           pip install pytest
 
-        # Step 4 - Run tests
+      # Step 4 - Run migrations
+      - name: Run migrations
+        run: |
+          export CONFIG=production
+          flask db upgrade
+
+      # Step 5 - Seed demo data
+      - name: Seed demo data
+        run: |
+          export CONFIG=production
+          flask seed-demo
+
+      # Step 6 - Run tests
       - name: Run pytest
         run: |
           export PYTHONPATH=$PYTHONPATH:$(pwd)
+          export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/insightful_orders_test
           export REDIS_URL=redis://localhost:6379/0
           export JWT_SECRET_KEY=dummysecret
-          pytest --maxfail=1 --disable-warnings -q -m "not integration"
+          pytest --maxfail=1 --disable-warnings -q
 
-      # Step 5 - Log in to GitHub Container Registry
+      # Step 7 - Log in to GitHub Container Registry
       - name: Log in to GHCR
         uses: docker/login-action@v2
         with:
@@ -44,12 +77,12 @@ jobs:
           username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GHCR_TOKEN }}
 
-      # Step 6 - Build Docker image
+      # Step 8 - Build Docker image
       - name: Build Docker image
         run: |
           docker build -t ghcr.io/${{ secrets.GHCR_USERNAME }}/insightful-orders:latest .
 
-      # Step 7 - Push Docker image
+      # Step 9 - Push Docker image
       - name: Push Docker image
         run: |
           docker push ghcr.io/${{ secrets.GHCR_USERNAME }}/insightful-orders:latest


### PR DESCRIPTION
Key changes made to CI.yml:

- Added Run migrations (flask db upgrade).
- Added Seed demo data (flask seed-demo).
- Updated pytest step to use the test Postgres DB (DATABASE_URL=postgresql://postgres:postgres@localhost:5432/insightful_orders_test).
- Removed -m "not integration" so integration tests (like your /auth/login + WebSockets) actually run against seeded demo data.